### PR TITLE
"pkg info" instead of "pkg list", replace "awk | sed" pipe with single "sed"

### DIFF
--- a/bsdfetch
+++ b/bsdfetch
@@ -14,7 +14,7 @@ main() {
 	boot_time=
 	case $os in
 		Free*|Midnight*|Dragon*)
-			boot_time=$(sysctl -n kern.boottime | awk '{printf $4}' | sed s/,//)
+			boot_time=$(sysctl -n kern.boottime | sed -E 's/.* sec = ([[:digit:]]+).*/\1/')
 		;;
 		Open*|Net*)
 			boot_time=$(sysctl -n kern.boottime)
@@ -32,7 +32,7 @@ main() {
 	ctl_mem=
 	case $os in
 		Free*|DragonFly*)
-			pkgs=$(pkg list | wc -l | sed "s/[[:space:]]//g")
+			pkgs=$(pkg info -q | wc -l | sed "s/[[:space:]]//g")
 		;;
 		Midnight*)
 			pkgs=$(mport list | wc -l | sed "s/[[:space:]]//g")


### PR DESCRIPTION
1. pkg doesn't have "list" command on FreeBSD, it's alias (if any) to "pkg info -ql". And it lists **all** files in packages. We need to use "pkg info -q" to count packages.
2. Only "sed" is lighter and faster than "awk | sed" pipe